### PR TITLE
Home port refactored

### DIFF
--- a/DataManager/include/datamanager.h
+++ b/DataManager/include/datamanager.h
@@ -34,8 +34,6 @@
 /* Function to handle configurations */
 Configuration *configurationNew();
 void           configurationFree(Configuration *config);
-mxml_node_t   *configurationToXml(Configuration *configuration, mxml_node_t *parent);
-json_t        *configurationToJson(Configuration *configuration);
 int            configurationAddListener(Configuration *configuration, Listener *l);
 int            configurationRemoveListener(Configuration *configuration, Listener *l);
 
@@ -52,7 +50,7 @@ void         deviceFree          (Device *device);
 Service*     serviceNew            (Device *device, const char *description, int isActuator, const char *type, const char *unit,
                                     serviceGetFunction getFunction, servicePutFunction putFunction, Parameter *parameter, void* data, free_f free_data); 
 void         serviceFree           (Service *service);
-int          serviceGenerateUri    (Service *service);
+int          serviceGenerateIds    (Service *service);
 int          serviceAddListener    (Service *service, Listener *l);
 int          serviceRemoveListener (Service *service, Listener *l);
 
@@ -65,8 +63,8 @@ void       parameterFree (Parameter *parameter);
 Adapter *configurationFindFirstAdapter(Configuration *configuration, const char *id, const char *network);
 Device  *adapterFindFirstDevice       (Adapter *adapter, const char *description, const char *id, const char *vendorId,
                                        const char *productId, const char *version, const char *location, const char *type);
-Service *deviceFindFirstService       (Device *device, const char *description, const int  *isActuator, const char *type,
-                                       const char *unit, const char *id, const char *uri);
+Service *deviceFindFirstService(Device *device, const char *description, const int *isActuator, const char *type,
+                                const char *unit, const char *id);
 Service *configurationServiceLookup(Configuration *configuration, const char *dtype, const char *did, const char *stype, const char *sid);
 Service *adapterServiceLookup(Adapter *adapter, const char *dtype, const char *did, const char *stype, const char *sid);
 

--- a/DataManager/include/datamanager.h
+++ b/DataManager/include/datamanager.h
@@ -38,19 +38,18 @@ int            configurationAddListener(Configuration *configuration, Listener *
 int            configurationRemoveListener(Configuration *configuration, Listener *l);
 
 /* Function to handle adapters */
-Adapter     *adapterNew          (Configuration *configuration, const char *network, void *data, free_f free_data);
+int          adapterNew          (Adapter **adapter, Configuration *configuration, const char *id, const char *network, void *data, free_f free_data);
 void         adapterFree         (Adapter *adapter);
 
 /* Function to handle devices */
-Device*      deviceNew           (Adapter *adapter, const char *description, const char *vendorId, const char *productId,
+int          deviceNew           (Device** device, Adapter *adapter, const char *id, const char *description, const char *vendorId, const char *productId,
                                   const char *version, const char *location, const char *type, void *data, free_f free_data);
 void         deviceFree          (Device *device); 
 
 /* Function to handle services */
-Service*     serviceNew            (Device *device, const char *description, int isActuator, const char *type, const char *unit,
+int          serviceNew            (Service **service, Device *device, const char *id, const char *description, int isActuator, const char *type, const char *unit,
                                     serviceGetFunction getFunction, servicePutFunction putFunction, Parameter *parameter, void* data, free_f free_data); 
 void         serviceFree           (Service *service);
-int          serviceGenerateIds    (Service *service);
 int          serviceAddListener    (Service *service, Listener *l);
 int          serviceRemoveListener (Service *service, Listener *l);
 

--- a/DataManager/include/datamanager.h
+++ b/DataManager/include/datamanager.h
@@ -67,5 +67,7 @@ Device  *adapterFindFirstDevice       (Adapter *adapter, const char *description
                                        const char *productId, const char *version, const char *location, const char *type);
 Service *deviceFindFirstService       (Device *device, const char *description, const int  *isActuator, const char *type,
                                        const char *unit, const char *id, const char *uri);
+Service *configurationServiceLookup(Configuration *configuration, const char *dtype, const char *did, const char *stype, const char *sid);
+Service *adapterServiceLookup(Adapter *adapter, const char *dtype, const char *did, const char *stype, const char *sid);
 
 #endif

--- a/DataManager/include/datamanager.h
+++ b/DataManager/include/datamanager.h
@@ -64,7 +64,7 @@ Device  *adapterFindFirstDevice       (Adapter *adapter, const char *description
                                        const char *productId, const char *version, const char *location, const char *type);
 Service *deviceFindFirstService(Device *device, const char *description, const int *isActuator, const char *type,
                                 const char *unit, const char *id);
-Service *configurationServiceLookup(Configuration *configuration, const char *dtype, const char *did, const char *stype, const char *sid);
-Service *adapterServiceLookup(Adapter *adapter, const char *dtype, const char *did, const char *stype, const char *sid);
+Service *configurationServiceLookup(Configuration *configuration, const char *aid, const char *did, const char *sid);
+Service *adapterServiceLookup(Adapter *adapter, const char *did, const char *sid);
 
 #endif

--- a/DataManager/include/datamanager.h
+++ b/DataManager/include/datamanager.h
@@ -38,8 +38,10 @@ int            configurationAddListener(Configuration *configuration, Listener *
 int            configurationRemoveListener(Configuration *configuration, Listener *l);
 
 /* Function to handle adapters */
-int          adapterNew          (Adapter **adapter, Configuration *configuration, const char *id, const char *network, void *data, free_f free_data);
-void         adapterFree         (Adapter *adapter);
+int          adapterNew            (Adapter **adapter, Configuration *configuration, const char *id, const char *network, void *data, free_f free_data);
+void         adapterFree           (Adapter *adapter);
+int          adapterAddListener    (Adapter *adapter, Listener *l);
+int          adapterRemoveListener (Adapter *adapter, Listener *l);
 
 /* Function to handle devices */
 int          deviceNew           (Device** device, Adapter *adapter, const char *id, const char *description, const char *vendorId, const char *productId,

--- a/DataManager/include/datamanager.h
+++ b/DataManager/include/datamanager.h
@@ -49,7 +49,7 @@ int          deviceNew           (Device** device, Adapter *adapter, const char 
 void         deviceFree          (Device *device); 
 
 /* Function to handle services */
-int          serviceNew            (Service **service, Device *device, const char *id, const char *description, int isActuator, const char *type, const char *unit,
+int          serviceNew            (Service **service, Device *device, const char *id, const char *description, const char *type, const char *unit,
                                     serviceGetFunction getFunction, servicePutFunction putFunction, Parameter *parameter, void* data, free_f free_data); 
 void         serviceFree           (Service *service);
 int          serviceAddListener    (Service *service, Listener *l);
@@ -64,7 +64,7 @@ void       parameterFree (Parameter *parameter);
 Adapter *configurationFindFirstAdapter(Configuration *configuration, const char *id, const char *network);
 Device  *adapterFindFirstDevice       (Adapter *adapter, const char *description, const char *id, const char *vendorId,
                                        const char *productId, const char *version, const char *location, const char *type);
-Service *deviceFindFirstService(Device *device, const char *description, const int *isActuator, const char *type,
+Service *deviceFindFirstService(Device *device, const char *description, const char *type,
                                 const char *unit, const char *id);
 Service *configurationServiceLookup(Configuration *configuration, const char *aid, const char *did, const char *sid);
 Service *adapterServiceLookup(Adapter *adapter, const char *did, const char *sid);

--- a/DataManager/include/hpd_datamanager.h
+++ b/DataManager/include/hpd_datamanager.h
@@ -26,13 +26,13 @@ authors and should not be interpreted as representing official policies, either 
 #ifndef HOMEPORT_HPD_DATAMANAGER_H
 #define HOMEPORT_HPD_DATAMANAGER_H
 
-typedef       struct Configuration Configuration;
-typedef       struct Adapter Adapter;
-typedef       struct Device Device;
-typedef       struct Service Service;
-typedef       struct Parameter Parameter;
-typedef const struct Request Request;
-typedef       struct Listener Listener;
+typedef struct Configuration Configuration;
+typedef struct Adapter Adapter;
+typedef struct Device Device;
+typedef struct Service Service;
+typedef struct Parameter Parameter;
+typedef struct Request Request;
+typedef struct Listener Listener;
 
 typedef       enum error_code ErrorCode;
 

--- a/DataManager/include/hpd_datamanager.h
+++ b/DataManager/include/hpd_datamanager.h
@@ -132,8 +132,6 @@ struct Service
     serviceGetFunction  getFunction; /**<A pointer to the GET function of the Service*/
     servicePutFunction  putFunction; /**<A pointer to the PUT function of the Service*/
     char               *id;          /**<The Service ID*/
-    // TODO Does it make sense to store uris here when libREST is no longer included?
-    char               *uri;         /**<The Service URI*/
     // User data
     free_f              free_data;
     void               *data;        /**<Pointer used for the used to store its data*/

--- a/DataManager/include/hpd_datamanager.h
+++ b/DataManager/include/hpd_datamanager.h
@@ -127,7 +127,6 @@ struct Service
     Listener           *listener_head;
     // Data members
     char               *description; /**<The Service description*/
-    int                 isActuator;  /**<Determine if the service is an actuator or a sensro */
     char               *type;        /**<The Service type*/
     char               *unit;        /**<The unit provided by the Service*/
     serviceGetFunction  getFunction; /**<A pointer to the GET function of the Service*/

--- a/DataManager/include/hpd_datamanager.h
+++ b/DataManager/include/hpd_datamanager.h
@@ -86,6 +86,7 @@ struct Adapter
     Device        *device_head;
     Adapter       *next;
     Adapter       *prev;
+    Listener      *listener_head;
     // Data members
     char          *id;
     char          *network;
@@ -154,11 +155,12 @@ struct Request {
 };
 
 struct Listener {
-    enum { SERVICE_LISTENER, DEVICE_LISTENER } type;
+    enum { SERVICE_LISTENER, CONFIGURATION_LISTENER, ADAPTER_LISTENER } type;
     // Navigational members
     union {
         Service  *service;
         Configuration *configuration;
+        Adapter *adapter;
     };
     Listener *next;
     Listener *prev;

--- a/DataManager/src/dm_internal.h
+++ b/DataManager/src/dm_internal.h
@@ -35,15 +35,12 @@ int            configurationRemoveAdapter(Adapter *adapter );
 /* Function to handle adapters */
 int          adapterAddDevice    (Adapter *adapter, Device *device);
 int          adapterRemoveDevice (Device *device);
-int          adapterGenerateId   (Adapter *adapter);
 
 /* Function to handle devices */
 int          deviceAddService    (Device *device, Service *service);
 int          deviceRemoveService (Service *service);
-int          deviceGenerateId    (Device *device);
 
 /* Function to handle services */
-int          serviceGenerateId  (Service *service);
 
 // Find functions shortcuts
 #define configurationFindAdapter(_HP, _ID) configurationFindFirstAdapter(_HP, _ID, NULL)

--- a/DataManager/src/dm_internal.h
+++ b/DataManager/src/dm_internal.h
@@ -45,6 +45,6 @@ int          deviceRemoveService (Service *service);
 // Find functions shortcuts
 #define configurationFindAdapter(_HP, _ID) configurationFindFirstAdapter(_HP, _ID, NULL)
 #define adapterFindDevice(_A, _ID) adapterFindFirstDevice(_A, NULL, _ID, NULL, NULL, NULL, NULL, NULL)
-#define deviceFindService(_D, _ID) deviceFindFirstService(_D, NULL, NULL, NULL, NULL, _ID)
+#define deviceFindService(_D, _ID) deviceFindFirstService(_D, NULL, NULL, NULL, _ID)
 
 #endif

--- a/DataManager/src/dm_internal.h
+++ b/DataManager/src/dm_internal.h
@@ -35,25 +35,19 @@ int            configurationRemoveAdapter(Adapter *adapter );
 /* Function to handle adapters */
 int          adapterAddDevice    (Adapter *adapter, Device *device);
 int          adapterRemoveDevice (Device *device);
-mxml_node_t *adapterToXml        (Adapter *adapter, mxml_node_t *parent);
-json_t      *adapterToJson       (Adapter *adapter);
 int          adapterGenerateId   (Adapter *adapter);
 
 /* Function to handle devices */
-mxml_node_t *deviceToXml         (Device *device, mxml_node_t *parent);
-json_t      *deviceToJson        (Device *device);
 int          deviceAddService    (Device *device, Service *service);
 int          deviceRemoveService (Service *service);
 int          deviceGenerateId    (Device *device);
 
 /* Function to handle services */
-mxml_node_t* serviceToXml       (Service *service, mxml_node_t *parent);
-json_t*      serviceToJson      (Service *service);
 int          serviceGenerateId  (Service *service);
 
 // Find functions shortcuts
 #define configurationFindAdapter(_HP, _ID) configurationFindFirstAdapter(_HP, _ID, NULL)
 #define adapterFindDevice(_A, _ID) adapterFindFirstDevice(_A, NULL, _ID, NULL, NULL, NULL, NULL, NULL)
-#define deviceFindService(_D, _ID) deviceFindFirstService(_D, NULL, NULL, NULL, NULL, _ID, NULL)
+#define deviceFindService(_D, _ID) deviceFindFirstService(_D, NULL, NULL, NULL, NULL, _ID)
 
 #endif

--- a/DataManager/src/hpd_adapter.c
+++ b/DataManager/src/hpd_adapter.c
@@ -91,6 +91,9 @@ adapterAddDevice(Adapter *adapter, Device *device)
 {
   if(adapter == NULL || device == NULL) return HPD_E_NULL_POINTER;
 
+  if (adapterFindDevice(adapter, device->id))
+    return HPD_E_ID_NOT_UNIQUE;
+
   device->adapter = adapter;
   DL_APPEND( adapter->device_head, device);
 

--- a/DataManager/src/hpd_adapter.c
+++ b/DataManager/src/hpd_adapter.c
@@ -150,90 +150,11 @@ Service *adapterServiceLookup(Adapter *adapter, const char *dtype, const char *d
   DL_FOREACH(adapter->device_head, device)
   {
     if (strcmp(device->type, dtype) == 0 && strcmp(device->id, did) == 0) {
-      service = deviceFindFirstService(device, NULL, NULL, stype, NULL, sid, NULL);
+      service = deviceFindFirstService(device, NULL, NULL, stype, NULL, sid);
       if (service) return service;
     }
   }
 
-  return NULL;
-}
-
-mxml_node_t*
-adapterToXml(Adapter *adapter, mxml_node_t *parent)
-{
-  if(adapter == NULL) return NULL;
-
-  mxml_node_t *adapterXml;
-
-  adapterXml = mxmlNewElement(parent, "adapter");
-  if(adapter->id != NULL) mxmlElementSetAttr(adapterXml, "id", adapter->id);
-  if(adapter->network != NULL) mxmlElementSetAttr(adapterXml, "network", adapter->network);
-
-  Device *iterator;
-
-  DL_FOREACH( adapter->device_head, iterator)
-  {
-     if (iterator->attached)
-        deviceToXml(iterator, adapterXml);
-  }
-
-  return adapterXml;
-}
-
-json_t*
-adapterToJson(Adapter *adapter)
-{
-  json_t *adapterJson=NULL;
-  json_t *value=NULL;
-  json_t *deviceArray=NULL;
-
-  if( ( adapterJson = json_object() ) == NULL )
-  {
-    goto error;
-  }
-  if(adapter->id != NULL)
-  {
-    if( ( ( value = json_string(adapter->id) ) == NULL ) || ( json_object_set_new(adapterJson, "id", value) != 0 ) )
-    {
-      goto error;
-    }
-  }
-  if(adapter->network != NULL)
-  {
-    if( ( ( value = json_string(adapter->network) ) == NULL ) || ( json_object_set_new(adapterJson, "network", value) != 0 ) )
-    {
-      goto error;
-    }
-  }
-
-  Device *iterator;
-
-  if( ( deviceArray = json_array() ) == NULL )
-  {
-    goto error;
-  }
-
-  DL_FOREACH( adapter->device_head, iterator )
-  {
-     if (iterator->attached) {
-        json_t *device;
-        if( ( ( device = deviceToJson(iterator) ) == NULL ) || ( json_array_append_new(deviceArray, device) != 0 ) )
-        {
-          goto error;
-        }
-     }
-  }
-
-  if( json_object_set_new(adapterJson, "device", deviceArray) != 0 )
-  {
-    goto error;
-  }
-
-  return adapterJson;
-error:
-  if(adapterJson) json_decref(adapterJson);
-  if(value) json_decref(value);
-  if(deviceArray) json_decref(deviceArray);
   return NULL;
 }
 

--- a/DataManager/src/hpd_adapter.c
+++ b/DataManager/src/hpd_adapter.c
@@ -52,6 +52,7 @@ int adapterNew(Adapter **adapter, Configuration *configuration, const char *id, 
 
   (*adapter)->device_head = NULL;
   (*adapter)->configuration = NULL;
+  (*adapter)->listener_head = NULL;
 
   configurationAddAdapter(configuration, *adapter);
 
@@ -151,5 +152,23 @@ Service *adapterServiceLookup(Adapter *adapter, const char *did, const char *sid
     return NULL;
 
   return deviceFindService(device, sid);
+}
+
+int
+adapterAddListener(Adapter *adapter, Listener *l)
+{
+  if(adapter == NULL || l == NULL )
+    return HPD_E_NULL_POINTER;
+
+  DL_APPEND(adapter->listener_head, l);
+  return HPD_E_SUCCESS;
+}
+
+int
+adapterRemoveListener(Adapter *adapter, Listener *l)
+{
+  if(adapter == NULL || l == NULL ) return HPD_E_NULL_POINTER;
+  DL_DELETE(adapter->listener_head, l );
+  return HPD_E_SUCCESS;
 }
 

--- a/DataManager/src/hpd_adapter.c
+++ b/DataManager/src/hpd_adapter.c
@@ -140,6 +140,24 @@ adapterFindFirstDevice(Adapter *adapter,
   return NULL;
 }
 
+Service *adapterServiceLookup(Adapter *adapter, const char *dtype, const char *did, const char *stype, const char *sid)
+{
+  if( adapter == NULL ) return NULL;
+
+  Device *device = NULL;
+  Service *service = NULL;
+
+  DL_FOREACH(adapter->device_head, device)
+  {
+    if (strcmp(device->type, dtype) == 0 && strcmp(device->id, did) == 0) {
+      service = deviceFindFirstService(device, NULL, NULL, stype, NULL, sid, NULL);
+      if (service) return service;
+    }
+  }
+
+  return NULL;
+}
+
 mxml_node_t*
 adapterToXml(Adapter *adapter, mxml_node_t *parent)
 {

--- a/DataManager/src/hpd_adapter.c
+++ b/DataManager/src/hpd_adapter.c
@@ -142,21 +142,14 @@ adapterFindFirstDevice(Adapter *adapter,
   return NULL;
 }
 
-Service *adapterServiceLookup(Adapter *adapter, const char *dtype, const char *did, const char *stype, const char *sid)
+Service *adapterServiceLookup(Adapter *adapter, const char *did, const char *sid)
 {
   if( adapter == NULL ) return NULL;
 
-  Device *device = NULL;
-  Service *service = NULL;
+  Device *device = adapterFindDevice(adapter, did);
+  if (device == NULL)
+    return NULL;
 
-  DL_FOREACH(adapter->device_head, device)
-  {
-    if (strcmp(device->type, dtype) == 0 && strcmp(device->id, did) == 0) {
-      service = deviceFindFirstService(device, NULL, NULL, stype, NULL, sid);
-      if (service) return service;
-    }
-  }
-
-  return NULL;
+  return deviceFindService(device, sid);
 }
 

--- a/DataManager/src/hpd_configuration.c
+++ b/DataManager/src/hpd_configuration.c
@@ -33,7 +33,6 @@
 #include "hp_macros.h"
 #include "hpd_error.h"
 #include "utlist.h"
-#include "idgen.h"
 
 Configuration*
 configurationNew()
@@ -114,20 +113,15 @@ configurationFindFirstAdapter(Configuration *configuration,
   return NULL;
 }
 
-Service *configurationServiceLookup(Configuration *configuration, const char *dtype, const char *did, const char *stype, const char *sid)
+Service *configurationServiceLookup(Configuration *configuration, const char *aid, const char *did, const char *sid)
 {
     if( configuration== NULL ) return NULL;
 
-    Adapter *adapter = NULL;
-    Service *service = NULL;
+    Adapter *adapter = configurationFindAdapter(configuration, aid);
+    if (adapter == NULL)
+        return NULL;
 
-    DL_FOREACH(configuration->adapter_head, adapter)
-    {
-        service = adapterServiceLookup(adapter, dtype, did, stype, sid);
-        if (service) return service;
-    }
-
-    return NULL;
+    return adapterServiceLookup(adapter, did, sid);
 }
 
 int

--- a/DataManager/src/hpd_configuration.c
+++ b/DataManager/src/hpd_configuration.c
@@ -72,11 +72,6 @@ configurationAddAdapter(Configuration *configuration, Adapter *adapter)
   if(configuration == NULL || adapter == NULL) return HPD_E_NULL_POINTER;
 
   adapter->configuration = configuration;
-  int stat = adapterGenerateId(adapter);
-  if (stat) {
-     adapter->configuration = NULL;
-     return stat;
-  }
 
   DL_APPEND( configuration->adapter_head, adapter);
 

--- a/DataManager/src/hpd_configuration.c
+++ b/DataManager/src/hpd_configuration.c
@@ -116,6 +116,22 @@ configurationFindFirstAdapter(Configuration *configuration,
   return NULL;
 }
 
+Service *configurationServiceLookup(Configuration *configuration, const char *dtype, const char *did, const char *stype, const char *sid)
+{
+    if( configuration== NULL ) return NULL;
+
+    Adapter *adapter = NULL;
+    Service *service = NULL;
+
+    DL_FOREACH(configuration->adapter_head, adapter)
+    {
+        service = adapterServiceLookup(adapter, dtype, did, stype, sid);
+        if (service) return service;
+    }
+
+    return NULL;
+}
+
 mxml_node_t*
 configurationToXml(Configuration *configuration, mxml_node_t *parent)
 {

--- a/DataManager/src/hpd_configuration.c
+++ b/DataManager/src/hpd_configuration.c
@@ -71,6 +71,9 @@ configurationAddAdapter(Configuration *configuration, Adapter *adapter)
 {
   if(configuration == NULL || adapter == NULL) return HPD_E_NULL_POINTER;
 
+    if (configurationFindAdapter(configuration, adapter->id))
+        return HPD_E_ID_NOT_UNIQUE;
+
   adapter->configuration = configuration;
 
   DL_APPEND( configuration->adapter_head, adapter);

--- a/DataManager/src/hpd_configuration.c
+++ b/DataManager/src/hpd_configuration.c
@@ -132,64 +132,6 @@ Service *configurationServiceLookup(Configuration *configuration, const char *dt
     return NULL;
 }
 
-mxml_node_t*
-configurationToXml(Configuration *configuration, mxml_node_t *parent)
-{
-  mxml_node_t *configXml;
-
-  configXml = mxmlNewElement(parent, "configuration");
-
-  Adapter *iterator;
-
-  DL_FOREACH(configuration->adapter_head, iterator)
-  {
-    adapterToXml(iterator, configXml);
-  }
-
-  return configXml;
-}
-
-json_t*
-configurationToJson(Configuration *configuration)
-{
-  json_t *configJson=NULL;
-  json_t *adapterArray=NULL;
-  json_t *adapter=NULL;
-
-  if( ( configJson = json_object() ) == NULL )
-  {
-    goto error;
-  }
-
-  Adapter *iterator;
-
-  if( ( adapterArray = json_array() ) == NULL )
-  {
-    goto error;
-  } 
-
-  DL_FOREACH(configuration->adapter_head, iterator)
-  {
-    adapter = adapterToJson(iterator);
-    if( ( adapter == NULL ) || ( json_array_append_new(adapterArray, adapter) != 0 ) )
-    {
-      goto error;
-    }
-  }
-
-  if( json_object_set_new(configJson, "adapter", adapterArray) != 0 )
-  {
-    goto error;
-  }
-
-  return configJson;
-error:
-  if(adapter) json_decref(adapter);
-  if(adapterArray) json_decref(adapterArray);
-  if(configJson) json_decref(configJson);
-  return NULL;
-}
-
 int
 configurationAddListener(Configuration *configuration, Listener *l)
 {

--- a/DataManager/src/hpd_device.c
+++ b/DataManager/src/hpd_device.c
@@ -204,14 +204,9 @@ deviceRemoveService( Service *service )
    return -1;
 }
 
-Service*
-deviceFindFirstService(Device *device,
-      const char *description,
-      const int  *isActuator,
-      const char *type,
-      const char *unit,
-      const char *id,
-      const char *uri)
+Service *
+deviceFindFirstService(Device *device, const char *description, const int *isActuator, const char *type,
+                       const char *unit, const char *id)
 {
   if (device == NULL) return NULL;
 
@@ -224,125 +219,10 @@ deviceFindFirstService(Device *device,
         if ( type == NULL || (iterator->type != NULL && strcmp(type, iterator->type) == 0) )
           if ( unit == NULL || (iterator->unit != NULL && strcmp(unit, iterator->unit) == 0) )
             if ( id == NULL || (iterator->id != NULL && strcmp(id, iterator->id) == 0) )
-              if ( uri == NULL || (iterator->uri != NULL && strcmp(uri, iterator->uri) == 0) )
                 return iterator;
   }
 
   return NULL;
-}
-
-mxml_node_t*
-deviceToXml(Device *device, mxml_node_t *parent)
-{
-  if(device == NULL) return NULL;
-
-  mxml_node_t *deviceXml;
-
-  deviceXml = mxmlNewElement(parent, "device");
-  if(device->description != NULL) mxmlElementSetAttr(deviceXml, "desc", device->description);
-  if(device->id != NULL) mxmlElementSetAttr(deviceXml, "id", device->id);
-  if(device->vendorId != NULL) mxmlElementSetAttr(deviceXml, "vendorId", device->vendorId);
-  if(device->productId != NULL) mxmlElementSetAttr(deviceXml, "productId", device->productId);
-  if(device->version != NULL) mxmlElementSetAttr(deviceXml, "version", device->version);
-  if(device->location != NULL) mxmlElementSetAttr(deviceXml, "location", device->location);
-  if(device->type != NULL) mxmlElementSetAttr(deviceXml, "type", device->type);
-
-  Service *iterator;
-
-  DL_FOREACH( device->service_head, iterator )
-  {
-    serviceToXml(iterator, deviceXml);
-  }
-
-  return deviceXml;
-}
-
-json_t*
-deviceToJson(Device *device)
-{
-  json_t *deviceJson=NULL;
-  json_t *value=NULL;
-  json_t *serviceArray=NULL;
-
-  if( ( deviceJson = json_object() ) == NULL )
-  {
-    return NULL;
-  }
-  if(device->description != NULL)
-  {
-    if( ( ( value = json_string(device->description) ) == NULL ) || ( json_object_set_new(deviceJson, "desc", value) != 0 ) )
-    {
-      return NULL;
-    }
-  }
-  if(device->id != NULL)
-  {
-    if( ( ( value = json_string(device->id) ) == NULL ) || ( json_object_set_new(deviceJson, "id", value) != 0 ) )
-    {
-      return NULL;
-    }
-  }
-  if(device->vendorId != NULL)
-  {
-    if( ( ( value = json_string(device->vendorId) ) == NULL ) || ( json_object_set_new(deviceJson, "vendorId", value) != 0 ) )
-    {
-      return NULL;
-    }
-  }
-  if(device->productId != NULL) 
-  {
-    if( ( ( value = json_string( device->productId ) ) == NULL ) || ( json_object_set_new(deviceJson, "productId", value) != 0 ) )
-    {
-      return NULL;
-    }
-  }
-  if(device->version != NULL) 
-  {
-    if( ( ( value = json_string( device->version ) ) == NULL ) || ( json_object_set_new(deviceJson, "version", value) != 0 ) )
-    {
-      return NULL;
-    }
-  }
-  if(device->productId != NULL) 
-  {
-    if( ( ( value = json_string( device->productId ) ) == NULL ) || ( json_object_set_new(deviceJson, "productId", value) != 0 ) )
-    {
-      return NULL;
-    }
-  }
-  if(device->type != NULL)
-  { 
-    if( ( ( value = json_string( device->type ) ) == NULL ) || ( json_object_set_new(deviceJson, "type", value) != 0 ) )
-    {
-      return NULL;
-    }
-  }
-
-  Service *iterator;
-
-  if( ( serviceArray = json_array() ) == NULL )
-  {
-    return NULL;
-  }
-
-  DL_FOREACH( device->service_head, iterator )
-  {
-    if( json_array_append_new(serviceArray, serviceToJson(iterator)) != 0 )
-    {
-      return NULL;
-    }
-  }
-
-  if( json_object_set_new(deviceJson, "service", serviceArray) != 0 )
-  {
-    return NULL;
-  }
-
-  return deviceJson;
-//error:
-//  if(value) json_decref(value);
-//  if(serviceArray) json_decref(serviceArray);
-//  if(deviceJson) json_decref(deviceJson);
 }
 
 static int

--- a/DataManager/src/hpd_device.c
+++ b/DataManager/src/hpd_device.c
@@ -159,6 +159,9 @@ deviceAddService( Device *device, Service *service )
   if( service == NULL || device == NULL ) 
     return HPD_E_NULL_POINTER;
 
+    if (deviceFindService(device, service->id))
+        return HPD_E_ID_NOT_UNIQUE;
+
   service->device = device;
   DL_APPEND( device->service_head, service);
 

--- a/DataManager/src/hpd_device.c
+++ b/DataManager/src/hpd_device.c
@@ -203,7 +203,7 @@ deviceRemoveService( Service *service )
 }
 
 Service *
-deviceFindFirstService(Device *device, const char *description, const int *isActuator, const char *type,
+deviceFindFirstService(Device *device, const char *description, const char *type,
                        const char *unit, const char *id)
 {
   if (device == NULL) return NULL;
@@ -213,11 +213,10 @@ deviceFindFirstService(Device *device, const char *description, const int *isAct
   DL_FOREACH( device->service_head, iterator )
   {
     if ( description == NULL || (iterator->description != NULL && strcmp(description, iterator->description) == 0) )
-      if ( isActuator == NULL || *isActuator == iterator->isActuator )
-        if ( type == NULL || (iterator->type != NULL && strcmp(type, iterator->type) == 0) )
-          if ( unit == NULL || (iterator->unit != NULL && strcmp(unit, iterator->unit) == 0) )
-            if ( id == NULL || (iterator->id != NULL && strcmp(id, iterator->id) == 0) )
-                return iterator;
+      if ( type == NULL || (iterator->type != NULL && strcmp(type, iterator->type) == 0) )
+        if ( unit == NULL || (iterator->unit != NULL && strcmp(unit, iterator->unit) == 0) )
+          if ( id == NULL || (iterator->id != NULL && strcmp(id, iterator->id) == 0) )
+              return iterator;
   }
 
   return NULL;

--- a/DataManager/src/hpd_service.c
+++ b/DataManager/src/hpd_service.c
@@ -83,7 +83,6 @@ serviceNew(
   service->listener_head = NULL;
   service->device = NULL;
   service->id = NULL;
-  service->uri = NULL;
 
   null_ok_string_copy(service->description, description);
 
@@ -134,154 +133,10 @@ serviceFree( Service *service )
     free_pointer(service->type);
     free_pointer(service->unit);
     free_pointer(service->id);
-    free_pointer(service->uri);
     parameterFree(service->parameter);
     if (service->free_data) service->free_data(service->data);
     free(service);
   }
-}
-
-mxml_node_t *
-serviceToXml(Service *service, mxml_node_t *parent)
-{
-  mxml_node_t *serviceXml;
-
-  serviceXml = mxmlNewElement(parent, "service");
-  if(service->description != NULL) mxmlElementSetAttr(serviceXml, "desc", service->description);
-  if(service->id != NULL) mxmlElementSetAttr(serviceXml, "id", service->id);
-  if(service->uri != NULL) mxmlElementSetAttr(serviceXml, "uri", service->uri);
-  mxmlElementSetAttr(serviceXml, "isActuator", service->isActuator ? "1" : "0");
-  if(service->type != NULL) mxmlElementSetAttr(serviceXml, "type", service->type);
-  if(service->unit != NULL) mxmlElementSetAttr(serviceXml, "unit", service->unit);
-
-
-  if(service->parameter != NULL)
-  {
-    mxml_node_t *parameterXml = mxmlNewElement(serviceXml, "parameter");
-    if(service->parameter->max != NULL) mxmlElementSetAttr(parameterXml, "max", service->parameter->max);
-    if(service->parameter->min != NULL) mxmlElementSetAttr(parameterXml, "min", service->parameter->min);
-    if(service->parameter->scale != NULL) mxmlElementSetAttr(parameterXml, "scale", service->parameter->scale);
-    if(service->parameter->step != NULL) mxmlElementSetAttr(parameterXml, "step", service->parameter->step);
-    if(service->parameter->type != NULL) mxmlElementSetAttr(parameterXml, "type", service->parameter->type);
-    if(service->parameter->unit != NULL) mxmlElementSetAttr(parameterXml, "unit", service->parameter->unit);
-    if(service->parameter->values != NULL) mxmlElementSetAttr(parameterXml, "values", service->parameter->values);
-  }
-
-
-  return serviceXml;
-}
-
-json_t*
-serviceToJson(Service *service)
-{
-  json_t *serviceJson;
-  json_t *value;
-
-  if( ( serviceJson = json_object() ) == NULL )
-  {
-    return NULL;
-  }
-  if(service->description != NULL)
-  {
-    if( ( ( value = json_string(service->description) ) == NULL ) || ( json_object_set_new(serviceJson, "desc", value) != 0 ) )
-    {
-      return NULL;
-    }
-  }
-  if(service->id != NULL)
-  {
-    if( ( ( value = json_string(service->id) ) == NULL ) || ( json_object_set_new(serviceJson, "id", value) != 0 ) )
-    {
-      return NULL;
-    }
-  }
-  if(service->uri != NULL)
-  {
-    if( ( ( value = json_string(service->uri) ) == NULL ) || ( json_object_set_new(serviceJson, "uri", value) != 0 ) )
-    {
-      return NULL;
-    }
-  }
-  if( ( ( value = json_string( service->isActuator ? "1" : "0") ) == NULL ) || (json_object_set_new(serviceJson, "isActuator", value) != 0 ) )
-  {
-    return NULL;
-  }
-  if(service->type != NULL)
-  { 
-    if( ( ( value = json_string( service->type ) ) == NULL ) || ( json_object_set_new(serviceJson, "type", value) != 0 ) )
-    {
-      return NULL;
-    }
-  }
-  if(service->unit != NULL) 
-  {
-    if( ( ( value = json_string( service->unit ) ) == NULL ) || ( json_object_set_new(serviceJson, "unit", value) != 0 ) )
-    {
-      return NULL;
-    }
-  }
-
-
-  if(service->parameter != NULL)
-  {
-    json_t *parameterJson = json_object();
-    if( parameterJson == NULL )
-      return NULL;
-    if(service->parameter->max != NULL) 
-    {
-      if( ( ( value = json_string( service->parameter->max ) ) == NULL ) || ( json_object_set_new(parameterJson, "max", value) != 0 ) )
-      {
-	return NULL;
-      }
-    }
-    if(service->parameter->min != NULL)
-    {
-      if( ( ( value = json_string( service->parameter->min ) ) == NULL ) || ( json_object_set_new(parameterJson, "min", value) != 0 ) )
-      {
-	return NULL;
-      }
-    }
-    if(service->parameter->scale != NULL) 
-    {
-      if( ( ( value = json_string( service->parameter->scale ) ) == NULL ) || ( json_object_set_new(parameterJson, "scale", value) != 0 ) )
-      {
-	return NULL;
-      }
-    }
-    if(service->parameter->step != NULL) 
-    {
-      if( ( ( value = json_string( service->parameter->step ) ) == NULL ) || ( json_object_set_new(parameterJson, "step", value) != 0 ) )
-      {
-	return NULL;
-      }
-    }
-    if(service->parameter->type != NULL)
-    {
-      if( ( (value = json_string( service->parameter->type ) ) == NULL ) || ( json_object_set_new(parameterJson, "type", value) != 0 ) )
-      {
-	return NULL;
-      }
-    }
-    if(service->parameter->unit != NULL) 
-    {
-      if( ( ( value = json_string( service->parameter->unit ) ) == NULL ) || ( json_object_set_new(parameterJson, "unit", value) != 0 ) ) 
-      {
-	return NULL;
-      }
-    }
-    if(service->parameter->values != NULL) 
-    {
-      if( ( ( value = json_string( service->parameter->values ) ) == NULL ) || ( json_object_set_new(parameterJson, "values", value) != 0 ) )
-      {
-	return NULL;
-      }
-    }
-    if( json_object_set_new(serviceJson, "parameter", parameterJson) != 0 )
-    {
-      return NULL;
-    }
-  }
-  return serviceJson;
 }
 
 int
@@ -300,7 +155,7 @@ serviceGenerateId(Service *service)
 }
 
 int
-serviceGenerateUri( Service *service )
+serviceGenerateIds(Service *service)
 {
    int rc;
    Device *device = service->device;
@@ -313,21 +168,6 @@ serviceGenerateUri( Service *service )
    if (rc != HPD_E_SUCCESS && rc != HPD_E_ID_ALREADY_SET)
       return rc;
 
-   char *uri = malloc((strlen(device->type)+strlen(device->id)+strlen(service->type)+strlen(service->id)+4+1)*sizeof(char));
-   if( uri == NULL )
-      return HPD_E_MALLOC_ERROR;
-   uri[0] = '\0';
-   strcat(uri, "/");
-   strcat(uri, device->type);
-   strcat(uri, "/");
-   strcat(uri, device->id);
-   strcat(uri, "/");
-   strcat(uri, service->type);
-   strcat(uri, "/");
-   strcat(uri, service->id);
-
-   free_pointer(service->uri);
-   service->uri = uri;
    return HPD_E_SUCCESS;
 }
 

--- a/DataManager/src/hpd_service.c
+++ b/DataManager/src/hpd_service.c
@@ -64,7 +64,7 @@
  * 		id, type, device and get_function can not be NULL
  */
 int serviceNew(Service **service, Device *device,
-               const char *id, const char *description, int isActuator, const char *type, const char *unit,
+               const char *id, const char *description, const char *type, const char *unit,
                serviceGetFunction getFunction, servicePutFunction putFunction, Parameter *parameter,
                void* data, free_f free_data)
 {
@@ -78,8 +78,6 @@ int serviceNew(Service **service, Device *device,
 
     null_nok_string_copy((*service)->id, id);
     null_ok_string_copy((*service)->description, description);
-
-    (*service)->isActuator = isActuator;
 
     null_nok_string_copy((*service)->type, type);
 

--- a/Examples/hpd_example_easy.c
+++ b/Examples/hpd_example_easy.c
@@ -90,7 +90,8 @@ static int init(HomePort *homeport, void *data)
 {
     hpd_rest_init(data, homeport, 8890);
 
-    adapter = homePortNewAdapter(homeport, "test", NULL, NULL);
+    if (homePortNewAdapter(&adapter, homeport, "0", "test", NULL, NULL))
+        return 1;
 
     /** Creation and registration of non secure services */
     /** Create a device that will contain the services
@@ -106,12 +107,13 @@ static int init(HomePort *homeport, void *data)
      * 10th parameter : A flag indicating if the communication with the device should be secure
      * 				   HPD_SECURE_DEVICE or HPD_NON_SECURE_DEVICE
      */
-    device = homePortNewDevice(adapter, "Example",
+    if(homePortNewDevice(&device, adapter, "0", "Example",
                                "0x01",
                                "0x01",
                                "V1",
                                "LivingRoom",
-                               "Example", NULL, NULL);
+                               "Example", NULL, NULL))
+        return 1;
     /** Create a service
      * 1st parameter : The service's description (optional)
      * 2nd parameter : The service's id
@@ -122,33 +124,37 @@ static int init(HomePort *homeport, void *data)
      * 8th parameter : The service's PUT function (optional)
      * 9th parameter : The service's parameter structure
      */
-    service_lamp0 = homePortNewService (device, "Lamp0", 1, "Lamp", "ON/OFF",
+     if (homePortNewService (&service_lamp0, device, "1", "Lamp0", 1, "Lamp", "ON/OFF",
                                         get_lamp, put_lamp,
                                         homePortNewParameter (NULL, NULL,
                                                               NULL, NULL, NULL,
                                                               NULL, NULL)
-            ,NULL, NULL);
+            ,NULL, NULL))
+         return 1;
 
-    service_lamp1 = homePortNewService (device, "Lamp1", 1, "Lamp", "ON/OFF",
+     if (homePortNewService (&service_lamp1, device, "2", "Lamp1", 1, "Lamp", "ON/OFF",
                                         get_lamp, put_lamp,
                                         homePortNewParameter (NULL, NULL,
                                                               NULL, NULL, NULL,
                                                               NULL, NULL),
-                                        NULL, NULL);
+                                        NULL, NULL))
+         return 1;
 
-    service_switch0 = homePortNewService (device, "Switch0", 0, "Switch", "ON/OFF",
+     if (homePortNewService (&service_switch0, device, "3", "Switch0", 0, "Switch", "ON/OFF",
                                           get_switch, NULL,
                                           homePortNewParameter (NULL, NULL,
                                                                 NULL, NULL, NULL,
                                                                 NULL, NULL),
-                                          NULL, NULL);
+                                          NULL, NULL))
+         return 1;
 
-    service_switch1 = homePortNewService (device, "Switch1", 0, "Switch", "ON/OFF",
+     if (homePortNewService (&service_switch1, device, "4", "Switch1", 0, "Switch", "ON/OFF",
                                           get_switch, NULL,
                                           homePortNewParameter (NULL, NULL,
                                                                 NULL, NULL, NULL,
                                                                 NULL, NULL),
-                                          NULL, NULL);
+                                          NULL, NULL))
+         return 1;
 
     homePortAttachDevice(homeport, device);
 

--- a/Examples/hpd_example_easy.c
+++ b/Examples/hpd_example_easy.c
@@ -124,7 +124,7 @@ static int init(HomePort *homeport, void *data)
      * 8th parameter : The service's PUT function (optional)
      * 9th parameter : The service's parameter structure
      */
-     if (homePortNewService (&service_lamp0, device, "1", "Lamp0", 1, "Lamp", "ON/OFF",
+     if (homePortNewService (&service_lamp0, device, "1", "Lamp0", "Lamp", "ON/OFF",
                                         get_lamp, put_lamp,
                                         homePortNewParameter (NULL, NULL,
                                                               NULL, NULL, NULL,
@@ -132,7 +132,7 @@ static int init(HomePort *homeport, void *data)
             ,NULL, NULL))
          return 1;
 
-     if (homePortNewService (&service_lamp1, device, "2", "Lamp1", 1, "Lamp", "ON/OFF",
+     if (homePortNewService (&service_lamp1, device, "2", "Lamp1", "Lamp", "ON/OFF",
                                         get_lamp, put_lamp,
                                         homePortNewParameter (NULL, NULL,
                                                               NULL, NULL, NULL,
@@ -140,7 +140,7 @@ static int init(HomePort *homeport, void *data)
                                         NULL, NULL))
          return 1;
 
-     if (homePortNewService (&service_switch0, device, "3", "Switch0", 0, "Switch", "ON/OFF",
+     if (homePortNewService (&service_switch0, device, "3", "Switch0", "Switch", "ON/OFF",
                                           get_switch, NULL,
                                           homePortNewParameter (NULL, NULL,
                                                                 NULL, NULL, NULL,
@@ -148,7 +148,7 @@ static int init(HomePort *homeport, void *data)
                                           NULL, NULL))
          return 1;
 
-     if (homePortNewService (&service_switch1, device, "4", "Switch1", 0, "Switch", "ON/OFF",
+     if (homePortNewService (&service_switch1, device, "4", "Switch1", "Switch", "ON/OFF",
                                           get_switch, NULL,
                                           homePortNewParameter (NULL, NULL,
                                                                 NULL, NULL, NULL,

--- a/Misc/include/hp_macros.h
+++ b/Misc/include/hp_macros.h
@@ -37,10 +37,8 @@
 
 #define alloc_struct(p) 		\
   do {                                	\
-    typeof(*p) aszero_ ## p = {0};  	\
-    p = malloc(sizeof *p);          	\
+    p = calloc(1, sizeof *p);          	\
     if(p==NULL) goto cleanup; 		\
-    *p = aszero_ ## p;              	\
   } while (0)
 
 #define string_copy(copy, original) 			\

--- a/Misc/include/hpd_error.h
+++ b/Misc/include/hpd_error.h
@@ -62,7 +62,7 @@ authors and should not be interpreted as representing official policies, either 
 	
 #define HPD_E_CFG_FILE_ERROR				-4	/**< Error when trying to load the configuration from file */
 
-#define HPD_E_MALLOC_ERROR 				-5	/**< A malloc failed */
+#define HPD_E_ALLOC_ERROR 				-5	/**< A malloc failed */
 
 #define HPD_E_BAD_PARAMETER				-6	/**< A bad paramter has been given to HPD */
 
@@ -164,8 +164,9 @@ authors and should not be interpreted as representing official policies, either 
 
 #define HPD_E_ID_ALREADY_SET  -55
 
-#define HPD_E_DEVICE_ALREADY_ATTACHED  -56
+#define HPD_E_DEVICE_ATTACHED  -56
 #define HPD_E_DEVICE_NOT_ATTACHED  -57
+#define HPD_E_ID_NOT_UNIQUE -58
 
 
 

--- a/OperationHandler/homeport/include/homeport.h
+++ b/OperationHandler/homeport/include/homeport.h
@@ -81,15 +81,17 @@ Service *homePortFindFirstService(Device *device, const char *description, const
 Service *homePortServiceLookup(HomePort *homePort, const char *aid, const char *did, const char *sid);
 
 // Communication interface
-void      homePortRespond               (Service *service, Request req, ErrorCode code, const char *val, size_t len);
-void      homePortChanged               (Service *service, const char *val, size_t len);
-void      homePortGet                   (Service *service, val_err_cb on_response, void *data);
-void      homePortSet                   (Service *service, const char *val, size_t len, val_err_cb on_response, void *data);
-Listener *homePortNewServiceListener    (Service *srv, val_cb on_change, void *data, free_f on_free);
-Listener *homePortNewDeviceListener     (HomePort *hp, dev_cb on_attach, dev_cb on_detach, void *data, free_f on_free);
-void      homePortFreeListener          (Listener *l);
-void      homePortSubscribe             (Listener *l);
-void      homePortUnsubscribe           (Listener *l);
-void      homePortForAllAttachedDevices (Listener *l);
+void      homePortRespond                      (Service *service, Request req, ErrorCode code, const char *val, size_t len);
+void      homePortChanged                      (Service *service, const char *val, size_t len);
+void      homePortGet                          (Service *service, val_err_cb on_response, void *data);
+void      homePortSet                          (Service *service, const char *val, size_t len, val_err_cb on_response, void *data);
+Listener *homePortNewServiceListener           (Service *srv, val_cb on_change, void *data, free_f on_free);
+Listener *homePortNewDeviceListener            (HomePort *hp, dev_cb on_attach, dev_cb on_detach, void *data, free_f on_free);
+Listener *homePortAdapterNewDeviceListener     (Adapter *adapter, dev_cb on_attach, dev_cb on_detach, void *data, free_f on_free);
+void      homePortFreeListener                 (Listener *l);
+void      homePortSubscribe                    (Listener *l);
+void      homePortUnsubscribe                  (Listener *l);
+void      homePortForAllAttachedDevices        (Listener *l);
+void      homePortAdapterForAllAttachedDevices (Listener *l);
 
 #endif

--- a/OperationHandler/homeport/include/homeport.h
+++ b/OperationHandler/homeport/include/homeport.h
@@ -76,8 +76,8 @@ int        homePortDetachDevice     (HomePort *homeport, Device *device);
 Adapter *homePortFindFirstAdapter (HomePort *homeport, const char *id, const char *network);
 Device  *homePortFindFirstDevice  (Adapter *adapter, const char *description, const char *id, const char *vendorId,
                                    const char *productId, const char *version, const char *location, const char *type);
-Service *homePortFindFirstService (Device *device, const char *description, const int  *isActuator, const char *type,
-                                   const char *unit, const char *id, const char *uri);
+Service *homePortFindFirstService(Device *device, const char *description, const int *isActuator, const char *type,
+                                  const char *unit, const char *id);
 Service *homePortServiceLookup(HomePort *homePort, const char *dtype, const char *did, const char *stype, const char *sid);
 
 // Communication interface

--- a/OperationHandler/homeport/include/homeport.h
+++ b/OperationHandler/homeport/include/homeport.h
@@ -78,7 +78,7 @@ Device  *homePortFindFirstDevice  (Adapter *adapter, const char *description, co
                                    const char *productId, const char *version, const char *location, const char *type);
 Service *homePortFindFirstService(Device *device, const char *description, const int *isActuator, const char *type,
                                   const char *unit, const char *id);
-Service *homePortServiceLookup(HomePort *homePort, const char *dtype, const char *did, const char *stype, const char *sid);
+Service *homePortServiceLookup(HomePort *homePort, const char *aid, const char *did, const char *sid);
 
 // Communication interface
 void      homePortRespond               (Service *service, Request req, ErrorCode code, const char *val, size_t len);

--- a/OperationHandler/homeport/include/homeport.h
+++ b/OperationHandler/homeport/include/homeport.h
@@ -57,7 +57,7 @@ int        homePortEasy          (init_f init, deinit_f deinit, void *data);
 int        homePortNewAdapter    (Adapter **adapter, HomePort *homeport, const char *id, const char *network, void *data, free_f free_data);
 int        homePortNewDevice     (Device **device, Adapter *adapter, const char *id, const char *description, const char *vendorId, const char *productId,
                                   const char *version, const char *location, const char *type, void *data, free_f free_data);
-int        homePortNewService    (Service **service, Device *device, const char *id, const char *description, int isActuator, const char *type, const char *unit,
+int        homePortNewService    (Service **service, Device *device, const char *id, const char *description, const char *type, const char *unit,
                                   serviceGetFunction getFunction, servicePutFunction putFunction, Parameter *parameter, void* data, free_f free_data);
 Parameter *homePortNewParameter  (const char *max, const char *min, const char *scale, const char *step,
                                        const char *type, const char *unit, const char *values);
@@ -76,7 +76,7 @@ int        homePortDetachDevice     (HomePort *homeport, Device *device);
 Adapter *homePortFindFirstAdapter (HomePort *homeport, const char *id, const char *network);
 Device  *homePortFindFirstDevice  (Adapter *adapter, const char *description, const char *id, const char *vendorId,
                                    const char *productId, const char *version, const char *location, const char *type);
-Service *homePortFindFirstService(Device *device, const char *description, const int *isActuator, const char *type,
+Service *homePortFindFirstService(Device *device, const char *description, const char *type,
                                   const char *unit, const char *id);
 Service *homePortServiceLookup(HomePort *homePort, const char *aid, const char *did, const char *sid);
 

--- a/OperationHandler/homeport/include/homeport.h
+++ b/OperationHandler/homeport/include/homeport.h
@@ -78,6 +78,7 @@ Device  *homePortFindFirstDevice  (Adapter *adapter, const char *description, co
                                    const char *productId, const char *version, const char *location, const char *type);
 Service *homePortFindFirstService (Device *device, const char *description, const int  *isActuator, const char *type,
                                    const char *unit, const char *id, const char *uri);
+Service *homePortServiceLookup(HomePort *homePort, const char *dtype, const char *did, const char *stype, const char *sid);
 
 // Communication interface
 void      homePortRespond               (Service *service, Request req, ErrorCode code, const char *val, size_t len);

--- a/OperationHandler/homeport/include/homeport.h
+++ b/OperationHandler/homeport/include/homeport.h
@@ -54,11 +54,11 @@ void       homePortStop          (HomePort *homeport);
 int        homePortEasy          (init_f init, deinit_f deinit, void *data);
 
 // Configurator Interface
-Adapter   *homePortNewAdapter    (HomePort *homeport, const char *network, void *data, free_f free_data);
-Device    *homePortNewDevice     (Adapter *adapter, const char *description, const char *vendorId, const char *productId,
+int        homePortNewAdapter    (Adapter **adapter, HomePort *homeport, const char *id, const char *network, void *data, free_f free_data);
+int        homePortNewDevice     (Device **device, Adapter *adapter, const char *id, const char *description, const char *vendorId, const char *productId,
                                   const char *version, const char *location, const char *type, void *data, free_f free_data);
-Service   *homePortNewService    (Device *device, const char *description, int isActuator, const char *type, const char *unit,
-                                  serviceGetFunction getFunction, servicePutFunction putFunction, Parameter *parameter, void* data, free_f free_data); 
+int        homePortNewService    (Service **service, Device *device, const char *id, const char *description, int isActuator, const char *type, const char *unit,
+                                  serviceGetFunction getFunction, servicePutFunction putFunction, Parameter *parameter, void* data, free_f free_data);
 Parameter *homePortNewParameter  (const char *max, const char *min, const char *scale, const char *step,
                                        const char *type, const char *unit, const char *values);
 void       homePortFreeAdapter      (Adapter *adapter);

--- a/OperationHandler/homeport/src/CMakeLists.txt
+++ b/OperationHandler/homeport/src/CMakeLists.txt
@@ -34,7 +34,7 @@ add_library(hpd SHARED
       comm.c
       config.c
       )
-target_link_libraries(hpd DataManager idgen jansson mxml)
+target_link_libraries(hpd DataManager idgen)
 install (TARGETS hpd DESTINATION lib)
 set_target_properties(hpd PROPERTIES VERSION 0.0.0 SOVERSION 0)
 

--- a/OperationHandler/homeport/src/config.c
+++ b/OperationHandler/homeport/src/config.c
@@ -34,16 +34,7 @@ homePortAttachDevice( HomePort *homeport, Device *device )
     // Pre-checks
     if( homeport == NULL || device == NULL )
         return HPD_E_NULL_POINTER;
-    if (device->attached) return HPD_E_DEVICE_ALREADY_ATTACHED;
-
-    Service *iterator;
-    int rc;
-
-    DL_FOREACH( device->service_head, iterator )
-    {
-        rc = serviceGenerateIds(iterator);
-        if (rc != HPD_E_SUCCESS) return rc;
-    }
+    if (device->attached) return HPD_E_DEVICE_ATTACHED;
 
     device->attached = 1;
 
@@ -103,25 +94,25 @@ homePortDetachAllDevices(HomePort *homeport, Adapter *adapter)
     return HPD_E_SUCCESS;
 }
 
-Adapter   *homePortNewAdapter    (HomePort *homeport, const char *network, void *data, free_f free_data)
+int        homePortNewAdapter    (Adapter **adapter, HomePort *homeport, const char *id, const char *network, void *data, free_f free_data)
 {
-    return adapterNew(homeport->configuration, network, data, free_data);
+    return adapterNew(adapter, homeport->configuration, id, network, data, free_data);
 }
 
-Device    *homePortNewDevice     (Adapter *adapter, const char *description, const char *vendorId, const char *productId,
+int        homePortNewDevice     (Device **device, Adapter *adapter, const char *id, const char *description, const char *vendorId, const char *productId,
                                   const char *version, const char *location, const char *type, void *data, free_f free_data)
 {
-    return deviceNew(adapter, description, vendorId, productId, version, location, type, data, free_data);
+    return deviceNew(device, adapter, id, description, vendorId, productId, version, location, type, data, free_data);
 }
 
-Service   *homePortNewService    (Device *device, const char *description, int isActuator, const char *type, const char *unit,
-                                  serviceGetFunction getFunction, servicePutFunction putFunction, Parameter *parameter, void* data, free_f free_data)
+int        homePortNewService    (Service **service, Device *device, const char *id, const char *description, int isActuator, const char *type, const char *unit,
+        serviceGetFunction getFunction, servicePutFunction putFunction, Parameter *parameter, void* data, free_f free_data)
 {
     if (device->attached) {
         fprintf(stderr, "Cannot add a service to an attached device. Please detach device first.\n");
-        return NULL;
+        return HPD_E_DEVICE_ATTACHED;
     }
-    return serviceNew(device, description, isActuator, type, unit, getFunction, putFunction, parameter, data, free_data);
+    return serviceNew(service, device, id, description, isActuator, type, unit, getFunction, putFunction, parameter, data, free_data);
 }
 
 Parameter *homePortNewParameter  (const char *max, const char *min, const char *scale, const char *step,

--- a/OperationHandler/homeport/src/config.c
+++ b/OperationHandler/homeport/src/config.c
@@ -113,14 +113,14 @@ int        homePortNewDevice     (Device **device, Adapter *adapter, const char 
     return deviceNew(device, adapter, id, description, vendorId, productId, version, location, type, data, free_data);
 }
 
-int        homePortNewService    (Service **service, Device *device, const char *id, const char *description, int isActuator, const char *type, const char *unit,
+int        homePortNewService    (Service **service, Device *device, const char *id, const char *description, const char *type, const char *unit,
         serviceGetFunction getFunction, servicePutFunction putFunction, Parameter *parameter, void* data, free_f free_data)
 {
     if (device->attached) {
         fprintf(stderr, "Cannot add a service to an attached device. Please detach device first.\n");
         return HPD_E_DEVICE_ATTACHED;
     }
-    return serviceNew(service, device, id, description, isActuator, type, unit, getFunction, putFunction, parameter, data, free_data);
+    return serviceNew(service, device, id, description, type, unit, getFunction, putFunction, parameter, data, free_data);
 }
 
 Parameter *homePortNewParameter  (const char *max, const char *min, const char *scale, const char *step,
@@ -183,10 +183,10 @@ Device  *homePortFindFirstDevice  (Adapter *adapter, const char *description, co
     return adapterFindFirstDevice(adapter, description, id, vendorId, productId, version, location, type);
 }
 
-Service *homePortFindFirstService(Device *device, const char *description, const int *isActuator, const char *type,
+Service *homePortFindFirstService(Device *device, const char *description, const char *type,
                                   const char *unit, const char *id)
 {
-    return deviceFindFirstService(device, description, isActuator, type, unit, id);
+    return deviceFindFirstService(device, description, type, unit, id);
 }
 
 Service *homePortServiceLookup(HomePort *homePort, const char *aid, const char *did, const char *sid)

--- a/OperationHandler/homeport/src/config.c
+++ b/OperationHandler/homeport/src/config.c
@@ -41,7 +41,7 @@ homePortAttachDevice( HomePort *homeport, Device *device )
 
     DL_FOREACH( device->service_head, iterator )
     {
-        rc = serviceGenerateUri(iterator);
+        rc = serviceGenerateIds(iterator);
         if (rc != HPD_E_SUCCESS) return rc;
     }
 
@@ -179,10 +179,10 @@ Device  *homePortFindFirstDevice  (Adapter *adapter, const char *description, co
     return adapterFindFirstDevice(adapter, description, id, vendorId, productId, version, location, type);
 }
 
-Service *homePortFindFirstService (Device *device, const char *description, const int  *isActuator, const char *type,
-                                   const char *unit, const char *id, const char *uri)
+Service *homePortFindFirstService(Device *device, const char *description, const int *isActuator, const char *type,
+                                  const char *unit, const char *id)
 {
-    return deviceFindFirstService(device, description, isActuator, type, unit, id, uri);
+    return deviceFindFirstService(device, description, isActuator, type, unit, id);
 }
 
 Service *homePortServiceLookup(HomePort *homePort, const char *dtype, const char *did, const char *stype, const char *sid)

--- a/OperationHandler/homeport/src/config.c
+++ b/OperationHandler/homeport/src/config.c
@@ -185,4 +185,7 @@ Service *homePortFindFirstService (Device *device, const char *description, cons
     return deviceFindFirstService(device, description, isActuator, type, unit, id, uri);
 }
 
-
+Service *homePortServiceLookup(HomePort *homePort, const char *dtype, const char *did, const char *stype, const char *sid)
+{
+    return configurationServiceLookup(homePort->configuration, dtype, did, stype, sid);
+}

--- a/OperationHandler/homeport/src/config.c
+++ b/OperationHandler/homeport/src/config.c
@@ -176,7 +176,7 @@ Service *homePortFindFirstService(Device *device, const char *description, const
     return deviceFindFirstService(device, description, isActuator, type, unit, id);
 }
 
-Service *homePortServiceLookup(HomePort *homePort, const char *dtype, const char *did, const char *stype, const char *sid)
+Service *homePortServiceLookup(HomePort *homePort, const char *aid, const char *did, const char *sid)
 {
-    return configurationServiceLookup(homePort->configuration, dtype, did, stype, sid);
+    return configurationServiceLookup(homePort->configuration, aid, did, sid);
 }

--- a/REST/hpdREST/src/CMakeLists.txt
+++ b/REST/hpdREST/src/CMakeLists.txt
@@ -35,6 +35,6 @@ add_library(hpd_rest SHARED
       json.c
       xml.c
       )
-target_link_libraries(hpd_rest libREST)
+target_link_libraries(hpd_rest libREST jansson mxml)
 install (TARGETS hpd_rest DESTINATION lib)
 set_target_properties(hpd_rest PROPERTIES VERSION 0.0.0 SOVERSION 0)

--- a/REST/hpdREST/src/CMakeLists.txt
+++ b/REST/hpdREST/src/CMakeLists.txt
@@ -35,6 +35,6 @@ add_library(hpd_rest SHARED
       json.c
       xml.c
       )
-target_link_libraries(hpd_rest libREST jansson mxml)
+target_link_libraries(hpd_rest libREST jansson mxml curl)
 install (TARGETS hpd_rest DESTINATION lib)
 set_target_properties(hpd_rest PROPERTIES VERSION 0.0.0 SOVERSION 0)

--- a/REST/hpdREST/src/hpd_rest.c
+++ b/REST/hpdREST/src/hpd_rest.c
@@ -23,6 +23,7 @@
   The views and conclusions contained in the software and documentation are those of the
   authors and should not be interpreted as representing official policies, either expressed*/
 
+#include <stdlib.h>
 #include "hpd_rest.h"
 #include "homeport.h"
 #include "libREST.h"
@@ -42,7 +43,9 @@ static void on_dev_detach(void *data, Device *device) {
     Service *service;
     DL_FOREACH(device->service_head, service)
     {
-        lri_unregisterService(data, service->uri);
+        char *uri = lri_alloc_uri(service);
+        lri_unregisterService(data, uri);
+        free(uri);
     }
 }
 

--- a/REST/hpdREST/src/json.c
+++ b/REST/hpdREST/src/json.c
@@ -64,7 +64,7 @@ serviceToJson(Service *service)
     }
     free(uri);
   }
-  if( ( ( value = json_string( service->isActuator ? "1" : "0") ) == NULL ) || (json_object_set_new(serviceJson, "isActuator", value) != 0 ) )
+  if( ( ( value = json_string( (service->putFunction != NULL) ? "1" : "0") ) == NULL ) || (json_object_set_new(serviceJson, "isActuator", value) != 0 ) )
   {
     return NULL;
   }

--- a/REST/hpdREST/src/json.c
+++ b/REST/hpdREST/src/json.c
@@ -85,10 +85,12 @@ jsonParseState(char *json_value)
   }
 
   const char *ret = json_string_value(value);
+  char *ret_alloc = malloc((strlen(ret)+1)*sizeof(char));
+  strcpy(ret_alloc, ret);
 
   json_decref(json);
 
-  return ret;
+  return ret_alloc;
 
 error:
   return NULL;

--- a/REST/hpdREST/src/json.c
+++ b/REST/hpdREST/src/json.c
@@ -26,6 +26,7 @@
 #include "json.h"
 #include "datamanager.h"
 #include <jansson.h>
+#include <curl/curl.h>
 #include "utlist.h"
 #include "lr_interface.h"
 
@@ -311,11 +312,22 @@ configurationToJson(Configuration *configuration)
   json_t *configJson=NULL;
   json_t *adapterArray=NULL;
   json_t *adapter=NULL;
+  json_t *value=NULL;
 
   if( ( configJson = json_object() ) == NULL )
   {
     goto error;
   }
+
+#ifdef CURL_ICONV_CODESET_OF_HOST
+  curl_version_info_data *curl_ver = curl_version_info(CURLVERSION_NOW);
+  if (curl_ver->features & CURL_VERSION_CONV && curl_ver->iconv_ver_num != 0)
+    if(((value = json_string(CURL_ICONV_CODESET_OF_HOST)) == NULL) || (json_object_set_new(configJson, "urlEncodedCharset", value) != 0)) goto error;
+  else
+    if(((value = json_string("ASCII")) == NULL) || (json_object_set_new(configJson, "urlEncodedCharset", value) != 0)) goto error;
+#else
+  if(((value = json_string("ASCII")) == NULL) || (json_object_set_new(configJson, "urlEncodedCharset", value) != 0)) goto error;
+#endif
 
   Adapter *iterator;
 

--- a/REST/hpdREST/src/json.c
+++ b/REST/hpdREST/src/json.c
@@ -46,13 +46,16 @@ serviceToJson(Service *service)
       return NULL;
     }
   }
-  if(service->id != NULL)
+  char *sid = lri_url_encode(service->id);
+  if(sid != NULL)
   {
-    if( ( ( value = json_string(service->id) ) == NULL ) || ( json_object_set_new(serviceJson, "id", value) != 0 ) )
+    if((( value = json_string(sid) ) == NULL ) || (json_object_set_new(serviceJson, "id", value) != 0 ) )
     {
+      free(sid);
       return NULL;
     }
   }
+  free(sid);
   char *uri = lri_alloc_uri(service);
   if(uri != NULL)
   {
@@ -67,13 +70,16 @@ serviceToJson(Service *service)
   {
     return NULL;
   }
-  if(service->type != NULL)
+  char *stype = lri_url_encode(service->type);
+  if(stype != NULL)
   {
-    if( ( ( value = json_string( service->type ) ) == NULL ) || ( json_object_set_new(serviceJson, "type", value) != 0 ) )
+    if((( value = json_string(stype) ) == NULL ) || (json_object_set_new(serviceJson, "type", value) != 0 ) )
     {
+      free(stype);
       return NULL;
     }
   }
+  free(stype);
   if(service->unit != NULL)
   {
     if( ( ( value = json_string( service->unit ) ) == NULL ) || ( json_object_set_new(serviceJson, "unit", value) != 0 ) )
@@ -163,13 +169,16 @@ deviceToJson(Device *device)
       return NULL;
     }
   }
-  if(device->id != NULL)
+  char *did = lri_url_encode(device->id);
+  if(did != NULL)
   {
-    if( ( ( value = json_string(device->id) ) == NULL ) || ( json_object_set_new(deviceJson, "id", value) != 0 ) )
+    if((( value = json_string(did) ) == NULL ) || (json_object_set_new(deviceJson, "id", value) != 0 ) )
     {
+      free(did);
       return NULL;
     }
   }
+  free(did);
   if(device->vendorId != NULL)
   {
     if( ( ( value = json_string(device->vendorId) ) == NULL ) || ( json_object_set_new(deviceJson, "vendorId", value) != 0 ) )
@@ -198,13 +207,16 @@ deviceToJson(Device *device)
       return NULL;
     }
   }
-  if(device->type != NULL)
+  char *dtype = lri_url_encode(device->type);
+  if(dtype != NULL)
   {
-    if( ( ( value = json_string( device->type ) ) == NULL ) || ( json_object_set_new(deviceJson, "type", value) != 0 ) )
+    if((( value = json_string(dtype) ) == NULL ) || (json_object_set_new(deviceJson, "type", value) != 0 ) )
     {
+      free(dtype);
       return NULL;
     }
   }
+  free(dtype);
 
   Service *iterator;
 
@@ -244,13 +256,16 @@ adapterToJson(Adapter *adapter)
   {
     goto error;
   }
-  if(adapter->id != NULL)
+  char *aid = lri_url_encode(adapter->id);
+  if(aid != NULL)
   {
-    if( ( ( value = json_string(adapter->id) ) == NULL ) || ( json_object_set_new(adapterJson, "id", value) != 0 ) )
+    if(((value = json_string(aid) ) == NULL ) || (json_object_set_new(adapterJson, "id", value) != 0 ) )
     {
+      free(aid);
       goto error;
     }
   }
+  free(aid);
   if(adapter->network != NULL)
   {
     if( ( ( value = json_string(adapter->network) ) == NULL ) || ( json_object_set_new(adapterJson, "network", value) != 0 ) )

--- a/REST/hpdREST/src/json.c
+++ b/REST/hpdREST/src/json.c
@@ -47,16 +47,13 @@ serviceToJson(Service *service)
       return NULL;
     }
   }
-  char *sid = lri_url_encode(service->id);
-  if(sid != NULL)
+  if(service->id != NULL)
   {
-    if((( value = json_string(sid) ) == NULL ) || (json_object_set_new(serviceJson, "id", value) != 0 ) )
+    if((( value = json_string(service->id) ) == NULL ) || (json_object_set_new(serviceJson, "id", value) != 0 ) )
     {
-      free(sid);
       return NULL;
     }
   }
-  free(sid);
   char *uri = lri_alloc_uri(service);
   if(uri != NULL)
   {
@@ -71,16 +68,13 @@ serviceToJson(Service *service)
   {
     return NULL;
   }
-  char *stype = lri_url_encode(service->type);
-  if(stype != NULL)
+  if(service->type != NULL)
   {
-    if((( value = json_string(stype) ) == NULL ) || (json_object_set_new(serviceJson, "type", value) != 0 ) )
+    if((( value = json_string(service->type) ) == NULL ) || (json_object_set_new(serviceJson, "type", value) != 0 ) )
     {
-      free(stype);
       return NULL;
     }
   }
-  free(stype);
   if(service->unit != NULL)
   {
     if( ( ( value = json_string( service->unit ) ) == NULL ) || ( json_object_set_new(serviceJson, "unit", value) != 0 ) )
@@ -170,16 +164,13 @@ deviceToJson(Device *device)
       return NULL;
     }
   }
-  char *did = lri_url_encode(device->id);
-  if(did != NULL)
+  if(device->id != NULL)
   {
-    if((( value = json_string(did) ) == NULL ) || (json_object_set_new(deviceJson, "id", value) != 0 ) )
+    if((( value = json_string(device->id) ) == NULL ) || (json_object_set_new(deviceJson, "id", value) != 0 ) )
     {
-      free(did);
       return NULL;
     }
   }
-  free(did);
   if(device->vendorId != NULL)
   {
     if( ( ( value = json_string(device->vendorId) ) == NULL ) || ( json_object_set_new(deviceJson, "vendorId", value) != 0 ) )
@@ -208,16 +199,13 @@ deviceToJson(Device *device)
       return NULL;
     }
   }
-  char *dtype = lri_url_encode(device->type);
-  if(dtype != NULL)
+  if(device->type != NULL)
   {
-    if((( value = json_string(dtype) ) == NULL ) || (json_object_set_new(deviceJson, "type", value) != 0 ) )
+    if((( value = json_string(device->type) ) == NULL ) || (json_object_set_new(deviceJson, "type", value) != 0 ) )
     {
-      free(dtype);
       return NULL;
     }
   }
-  free(dtype);
 
   Service *iterator;
 
@@ -257,16 +245,13 @@ adapterToJson(Adapter *adapter)
   {
     goto error;
   }
-  char *aid = lri_url_encode(adapter->id);
-  if(aid != NULL)
+  if(adapter->id != NULL)
   {
-    if(((value = json_string(aid) ) == NULL ) || (json_object_set_new(adapterJson, "id", value) != 0 ) )
+    if(((value = json_string(adapter->id) ) == NULL ) || (json_object_set_new(adapterJson, "id", value) != 0 ) )
     {
-      free(aid);
       goto error;
     }
   }
-  free(aid);
   if(adapter->network != NULL)
   {
     if( ( ( value = json_string(adapter->network) ) == NULL ) || ( json_object_set_new(adapterJson, "network", value) != 0 ) )

--- a/REST/hpdREST/src/lr_interface.c
+++ b/REST/hpdREST/src/lr_interface.c
@@ -54,6 +54,7 @@ static struct lri_req *req_new(struct lr_request *req)
     lri_req->req = req;
     lri_req->req_str = NULL;
     lri_req->in_hpd = 0;
+    return lri_req;
 }
 
 static int on_req_destroy(void *srv_data, void **req_data, struct lr_request *req)

--- a/REST/hpdREST/src/lr_interface.c
+++ b/REST/hpdREST/src/lr_interface.c
@@ -227,20 +227,29 @@ setState(void *srv_data, void **req_data_in, struct lr_request *req, const char 
 
 char *lri_url_encode(const char *id)
 {
+    char *res;
     CURL *curl = curl_easy_init();
+
     if(curl)
-        return curl_easy_escape(curl, id, 0);
+        res = curl_easy_escape(curl, id, 0);
     else
-        return NULL;
+        res = NULL;
+
+    curl_easy_cleanup(curl);
+    return res;
 }
 
 char *lri_url_decode(const char *id)
 {
+    char *res;
     CURL *curl = curl_easy_init();
     if(curl)
-        return curl_easy_unescape(curl, id, 0, NULL);
+        res = curl_easy_unescape(curl, id, 0, NULL);
     else
-        return NULL;
+        res = NULL;
+
+    curl_easy_cleanup(curl);
+    return res;
 }
 
 char *lri_alloc_uri(Service *service)

--- a/REST/hpdREST/src/lr_interface.c
+++ b/REST/hpdREST/src/lr_interface.c
@@ -164,8 +164,15 @@ setState(void *srv_data, void **req_data_in, struct lr_request *req, const char 
             lri_req = req_new(req);
             (*req_data_in) = lri_req;
         }
-        if (lri_req->req_str) len += strlen(lri_req->req_str);
-        lri_req->req_str = realloc(lri_req->req_str, (len+1)*sizeof(char));
+
+        if (!lri_req->req_str) {
+            lri_req->req_str = malloc((len+1)*sizeof(char));
+            lri_req->req_str[0] = '\0';
+        } else {
+            len += strlen(lri_req->req_str);
+            lri_req->req_str = realloc(lri_req->req_str, (len+1)*sizeof(char));
+        }
+
         if (!lri_req->req_str) {
             fprintf(stderr, "Failed to allocate memory\n");
             lr_sendf(req, WS_HTTP_500, NULL, "Internal server error");

--- a/REST/hpdREST/src/lr_interface.c
+++ b/REST/hpdREST/src/lr_interface.c
@@ -217,7 +217,7 @@ setState(void *srv_data, void **req_data_in, struct lr_request *req, const char 
     // Keep open: As the adapter may keep a pointer to request, we better insure that it is not close due to a timeout
     lr_request_keep_open(req);
     lri_req->in_hpd = 1;
-    homePortSet(service, value, strlen(value), sendState, req);
+    homePortSet(service, value, strlen(value), sendState, lri_req);
 
     free(value);
 

--- a/REST/hpdREST/src/lr_interface.c
+++ b/REST/hpdREST/src/lr_interface.c
@@ -184,7 +184,8 @@ lri_registerService(struct lr *lr, Service *service)
      return HPD_E_SERVICE_ALREADY_REGISTER;
    }
 
-   printf("Registering service\n");
+    // TODO Prefix printf statements and print to stderr on errors !! (Entire hpdREST module)
+   printf("[rest] Registering service %s...\n", uri);
    rc = lr_register_service(lr,
        uri,
        getState, NULL, setState, NULL,

--- a/REST/hpdREST/src/lr_interface.c
+++ b/REST/hpdREST/src/lr_interface.c
@@ -186,7 +186,6 @@ setState(void *srv_data, void **req_data_in, struct lr_request *req, const char 
     struct lm *headersIn = lr_request_get_headers(req);
     char *contentType = lm_find(headersIn, "Content-Type");
     char *value;
-    int freeValue = 1;
     if(lri_req == NULL || lri_req->req_str == NULL)
     {
         lr_sendf(req, WS_HTTP_400, NULL, "400 Bad Request");
@@ -202,7 +201,6 @@ setState(void *srv_data, void **req_data_in, struct lr_request *req, const char 
              strncmp(contentType, "application/json;", 17) == 0 )
     {
         value = (char *) jsonParseState(lri_req->req_str);
-        freeValue = 0;
     }
     else
     {
@@ -221,7 +219,7 @@ setState(void *srv_data, void **req_data_in, struct lr_request *req, const char 
     lri_req->in_hpd = 1;
     homePortSet(service, value, strlen(value), sendState, req);
 
-    if(freeValue) free(value);
+    free(value);
 
     return 0;
 }

--- a/REST/hpdREST/src/lr_interface.c
+++ b/REST/hpdREST/src/lr_interface.c
@@ -227,9 +227,14 @@ setState(void *srv_data, void **req_data_in, struct lr_request *req, const char 
 char *lri_alloc_uri(Service *service)
 {
     Device *device = service->device;
-    char *uri = malloc((strlen(device->type)+strlen(device->id)+strlen(service->type)+strlen(service->id)+4+1)*sizeof(char));
+    Adapter *adapter = device->adapter;
+
+    char *uri = malloc((strlen(adapter->id)+strlen(device->type)+strlen(device->id)+strlen(service->type)+strlen(service->id)+5+1)*sizeof(char));
     if( uri == NULL ) return NULL;
     uri[0] = '\0';
+
+    strcat(uri, "/");
+    strcat(uri, adapter->id);
     strcat(uri, "/");
     strcat(uri, device->type);
     strcat(uri, "/");
@@ -238,6 +243,7 @@ char *lri_alloc_uri(Service *service)
     strcat(uri, service->type);
     strcat(uri, "/");
     strcat(uri, service->id);
+
     return uri;
 }
 

--- a/REST/hpdREST/src/lr_interface.c
+++ b/REST/hpdREST/src/lr_interface.c
@@ -36,7 +36,6 @@
 
 int on_req_destroy(void *srv_data, void **req_data, struct lr_request *req)
 {
-    free(*req_data);
     (*req_data) = NULL;
     return 0;
 }
@@ -104,14 +103,11 @@ getState(void *srv_data, void **req_data, struct lr_request *req, const char *bo
     return 1;
   }
 
-    // TODO Find a nicer solution to check if connection have been closed
-    // TODO This can be a memory leak ?
-    (*req_data) = malloc(sizeof(struct lr_request *));
     (*req_data) = req;
 
   // Keep open: As the adapter may keep a pointer to request, we better insure that it is not close due to a timeout
   lr_request_keep_open(req);
-  homePortGet(service, sendState, (*req_data));
+  homePortGet(service, sendState, req_data);
 
   // Stop parsing request, we don't need the body anyways
   return 1;

--- a/REST/hpdREST/src/lr_interface.c
+++ b/REST/hpdREST/src/lr_interface.c
@@ -49,6 +49,7 @@ sendState(Service *service, void *in, ErrorCode code, const char *val, size_t le
 {
     struct lri_req *lri = in;
     if (lri == NULL) return;
+    if (lri->req == NULL) return;
 
    char *buffer = NULL, *state = NULL;
    struct lm *headersIn = lr_request_get_headers(lri->req);

--- a/REST/hpdREST/src/lr_interface.c
+++ b/REST/hpdREST/src/lr_interface.c
@@ -43,14 +43,16 @@ struct lri_req {
 int on_req_destroy(void *srv_data, void **req_data, struct lr_request *req)
 {
     struct lri_req *lri_req = (struct lri_req *)(*req_data);
-    lri_req->req = NULL;
-    if (lri_req->req_str) {
-        free(lri_req->req_str);
-        lri_req->req_str = NULL;
-    }
-    if (lri_req->destroy) {
-        free(lri_req);
-        (*req_data) = NULL;
+    if (lri_req != NULL) {
+        lri_req->req = NULL;
+        if (lri_req->req_str) {
+            free(lri_req->req_str);
+            lri_req->req_str = NULL;
+        }
+        if (lri_req->destroy) {
+            free(lri_req);
+            (*req_data) = NULL;
+        }
     }
     return 0;
 }

--- a/REST/hpdREST/src/lr_interface.h
+++ b/REST/hpdREST/src/lr_interface.h
@@ -31,6 +31,8 @@
 
 struct lr_request;
 
+char *lri_alloc_uri(Service *service);
+
 int lri_registerService(struct lr *lr, Service *service);
 int lri_unregisterService(struct lr *lr, char* uri);
 int lri_getConfiguration(void *srv_data, void **req_data, struct lr_request *req, const char *body, size_t len);

--- a/REST/hpdREST/src/lr_interface.h
+++ b/REST/hpdREST/src/lr_interface.h
@@ -32,6 +32,8 @@
 struct lr_request;
 
 char *lri_alloc_uri(Service *service);
+char *lri_url_encode(const char *id);
+char *lri_url_decode(const char *id);
 
 int lri_registerService(struct lr *lr, Service *service);
 int lri_unregisterService(struct lr *lr, char* uri);

--- a/REST/hpdREST/src/xml.c
+++ b/REST/hpdREST/src/xml.c
@@ -67,14 +67,18 @@ serviceToXml(Service *service, mxml_node_t *parent)
 
   serviceXml = mxmlNewElement(parent, "service");
   if(service->description != NULL) mxmlElementSetAttr(serviceXml, "desc", service->description);
-  if(service->id != NULL) mxmlElementSetAttr(serviceXml, "id", service->id);
+  char *sid = lri_url_encode(service->id);
+  if(sid != NULL) mxmlElementSetAttr(serviceXml, "id", sid);
+  free(sid);
   char *uri = lri_alloc_uri(service);
   if(uri != NULL) {
     mxmlElementSetAttr(serviceXml, "uri", uri);
     free(uri);
   }
   mxmlElementSetAttr(serviceXml, "isActuator", service->isActuator ? "1" : "0");
-  if(service->type != NULL) mxmlElementSetAttr(serviceXml, "type", service->type);
+  char *stype = lri_url_encode(service->type);
+  if(stype != NULL) mxmlElementSetAttr(serviceXml, "type", stype);
+  free(stype);
   if(service->unit != NULL) mxmlElementSetAttr(serviceXml, "unit", service->unit);
 
 
@@ -103,12 +107,16 @@ deviceToXml(Device *device, mxml_node_t *parent)
 
   deviceXml = mxmlNewElement(parent, "device");
   if(device->description != NULL) mxmlElementSetAttr(deviceXml, "desc", device->description);
-  if(device->id != NULL) mxmlElementSetAttr(deviceXml, "id", device->id);
+  char *did = lri_url_encode(device->id);
+  if(did != NULL) mxmlElementSetAttr(deviceXml, "id", did);
+  free(did);
   if(device->vendorId != NULL) mxmlElementSetAttr(deviceXml, "vendorId", device->vendorId);
   if(device->productId != NULL) mxmlElementSetAttr(deviceXml, "productId", device->productId);
   if(device->version != NULL) mxmlElementSetAttr(deviceXml, "version", device->version);
   if(device->location != NULL) mxmlElementSetAttr(deviceXml, "location", device->location);
-  if(device->type != NULL) mxmlElementSetAttr(deviceXml, "type", device->type);
+  char *dtype = lri_url_encode(device->type);
+  if(dtype != NULL) mxmlElementSetAttr(deviceXml, "type", dtype);
+  free(dtype);
 
   Service *iterator;
 
@@ -128,7 +136,9 @@ adapterToXml(Adapter *adapter, mxml_node_t *parent)
   mxml_node_t *adapterXml;
 
   adapterXml = mxmlNewElement(parent, "adapter");
-  if(adapter->id != NULL) mxmlElementSetAttr(adapterXml, "id", adapter->id);
+  char *aid = lri_url_encode(adapter->id);
+  if(aid != NULL) mxmlElementSetAttr(adapterXml, "id", aid);
+  free(aid);
   if(adapter->network != NULL) mxmlElementSetAttr(adapterXml, "network", adapter->network);
 
   Device *iterator;

--- a/REST/hpdREST/src/xml.c
+++ b/REST/hpdREST/src/xml.c
@@ -68,18 +68,14 @@ serviceToXml(Service *service, mxml_node_t *parent)
 
   serviceXml = mxmlNewElement(parent, "service");
   if(service->description != NULL) mxmlElementSetAttr(serviceXml, "desc", service->description);
-  char *sid = lri_url_encode(service->id);
-  if(sid != NULL) mxmlElementSetAttr(serviceXml, "id", sid);
-  free(sid);
+  if(service->id != NULL) mxmlElementSetAttr(serviceXml, "id", service->id);
   char *uri = lri_alloc_uri(service);
   if(uri != NULL) {
     mxmlElementSetAttr(serviceXml, "uri", uri);
     free(uri);
   }
   mxmlElementSetAttr(serviceXml, "isActuator", service->isActuator ? "1" : "0");
-  char *stype = lri_url_encode(service->type);
-  if(stype != NULL) mxmlElementSetAttr(serviceXml, "type", stype);
-  free(stype);
+  if(service->type != NULL) mxmlElementSetAttr(serviceXml, "type", service->type);
   if(service->unit != NULL) mxmlElementSetAttr(serviceXml, "unit", service->unit);
 
 
@@ -108,16 +104,12 @@ deviceToXml(Device *device, mxml_node_t *parent)
 
   deviceXml = mxmlNewElement(parent, "device");
   if(device->description != NULL) mxmlElementSetAttr(deviceXml, "desc", device->description);
-  char *did = lri_url_encode(device->id);
-  if(did != NULL) mxmlElementSetAttr(deviceXml, "id", did);
-  free(did);
+  if(device->id != NULL) mxmlElementSetAttr(deviceXml, "id", device->id);
   if(device->vendorId != NULL) mxmlElementSetAttr(deviceXml, "vendorId", device->vendorId);
   if(device->productId != NULL) mxmlElementSetAttr(deviceXml, "productId", device->productId);
   if(device->version != NULL) mxmlElementSetAttr(deviceXml, "version", device->version);
   if(device->location != NULL) mxmlElementSetAttr(deviceXml, "location", device->location);
-  char *dtype = lri_url_encode(device->type);
-  if(dtype != NULL) mxmlElementSetAttr(deviceXml, "type", dtype);
-  free(dtype);
+  if(device->type != NULL) mxmlElementSetAttr(deviceXml, "type", device->type);
 
   Service *iterator;
 
@@ -137,9 +129,7 @@ adapterToXml(Adapter *adapter, mxml_node_t *parent)
   mxml_node_t *adapterXml;
 
   adapterXml = mxmlNewElement(parent, "adapter");
-  char *aid = lri_url_encode(adapter->id);
-  if(aid != NULL) mxmlElementSetAttr(adapterXml, "id", aid);
-  free(aid);
+  if(adapter->id != NULL) mxmlElementSetAttr(adapterXml, "id", adapter->id);
   if(adapter->network != NULL) mxmlElementSetAttr(adapterXml, "network", adapter->network);
 
   Device *iterator;

--- a/REST/hpdREST/src/xml.c
+++ b/REST/hpdREST/src/xml.c
@@ -74,7 +74,7 @@ serviceToXml(Service *service, mxml_node_t *parent)
     mxmlElementSetAttr(serviceXml, "uri", uri);
     free(uri);
   }
-  mxmlElementSetAttr(serviceXml, "isActuator", service->isActuator ? "1" : "0");
+  mxmlElementSetAttr(serviceXml, "isActuator", (service->putFunction != NULL) ? "1" : "0");
   if(service->type != NULL) mxmlElementSetAttr(serviceXml, "type", service->type);
   if(service->unit != NULL) mxmlElementSetAttr(serviceXml, "unit", service->unit);
 

--- a/REST/hpdREST/src/xml.c
+++ b/REST/hpdREST/src/xml.c
@@ -27,6 +27,7 @@
 #include "datamanager.h"
 #include <time.h>
 #include <mxml.h>
+#include <curl/curl.h>
 #include "utlist.h"
 #include "lr_interface.h"
 
@@ -158,6 +159,16 @@ configurationToXml(Configuration *configuration, mxml_node_t *parent)
   mxml_node_t *configXml;
 
   configXml = mxmlNewElement(parent, "configuration");
+
+#ifdef CURL_ICONV_CODESET_OF_HOST
+  curl_version_info_data *curl_ver = curl_version_info(CURLVERSION_NOW);
+  if (curl_ver->features & CURL_VERSION_CONV && curl_ver->iconv_ver_num != 0)
+    mxmlElementSetAttr(configXml, "urlEncodedCharset", CURL_ICONV_CODESET_OF_HOST);
+  else
+    mxmlElementSetAttr(configXml, "urlEncodedCharset", "ASCII");
+#else
+  mxmlElementSetAttr(configXml, "urlEncodedCharset", "ASCII");
+#endif
 
   Adapter *iterator;
 

--- a/REST/http-webserver/src/request.c
+++ b/REST/http-webserver/src/request.c
@@ -242,7 +242,7 @@ static void header_parser_field_value_pair_complete(void* data,
    struct http_request *req = data;
    char *existing = lm_find_n(req->headers, field, field_length);
 
-   printf("Header: %.*s\n", (int)field_length, field);
+   //printf("Header: %.*s\n", (int)field_length, field);
 
    // If cookie, then store it in cookie list
    if (strncmp(field, "Cookie", 6) == 0) {
@@ -349,7 +349,7 @@ static int parser_url(http_parser *parser, const char *buf, size_t len)
       case S_BEGIN:
          // Send method
          method = http_method_str(parser->method);
-         printf("Method: %s\n", method);
+         //printf("Method: %s\n", method);
          if(method_cb)
             stat = method_cb(req->webserver, req, settings->ws_ctx, &req->data, method, strlen(method));
          if (stat) { req->state = S_STOP; return stat; }

--- a/REST/libREST/src/instance.c
+++ b/REST/libREST/src/instance.c
@@ -106,7 +106,7 @@ static int on_url_cmpl(struct httpws *ins, struct http_request *req,
   struct lr *lr_ins = ws_ctx;
   const char *url = http_request_get_url(req);
 
-  printf("Got request for '%s'\n", url);
+  printf("[librest] Got request for '%s'\n", url);
 
   if (url == NULL) {
     struct http_response *res = http_response_create(req, WS_HTTP_400);
@@ -119,7 +119,7 @@ static int on_url_cmpl(struct httpws *ins, struct http_request *req,
   struct trie_iter *iter = trie_lookup(lr_ins->trie, url);
 
   if (iter == NULL) { // URL not registered
-     fprintf(stderr, "Service on '%s' not found\n", url);
+     fprintf(stderr, "[librest] Service on '%s' not found\n", url);
      struct http_response *res = http_response_create(req, WS_HTTP_404);
      // TODO: Find out if we need to add headers
      http_response_sendf(res, "Resource not found"); // TODO: Decide on appropriate body

--- a/REST/webserver/src/webserver.c
+++ b/REST/webserver/src/webserver.c
@@ -216,10 +216,10 @@ static void *get_in_addr(struct sockaddr *sa)
 {
    if (sa->sa_family == AF_INET) {
       // IPv4
-      return &(((struct sockaddr_in*)sa)->sin_addr);
+      return &(((struct sockaddr_in*)sa)->sin_addr.s_addr);
    } else {
       // IPv6
-      return &(((struct sockaddr_in6*)sa)->sin6_addr);
+      return &(((struct sockaddr_in6*)sa)->sin6_addr.s6_addr);
    }
 }
 
@@ -384,7 +384,7 @@ static void ws_conn_accept(
    struct ws_settings *settings = &((struct ws *)watcher->data)->settings;
    
    // Accept connection
-   in_size = sizeof in_addr;
+   in_size = sizeof *in_addr;
    if ((in_fd = accept(watcher->fd, in_addr, &in_size)) < 0) {
       perror("accept");
       return;

--- a/REST/webserver/src/webserver.c
+++ b/REST/webserver/src/webserver.c
@@ -242,18 +242,18 @@ static void conn_recv_cb(struct ev_loop *loop, struct ev_io *watcher,
    size_t maxdatasize = settings->maxdatasize;
    char buffer[maxdatasize];
 
-   printf("recieving data from %s\n", conn->ip);
+   printf("[ws] Receiving data from %s\n", conn->ip);
    if ((recieved = recv(watcher->fd, buffer, maxdatasize-1, 0)) < 0) {
       if (recieved == -1 && errno == EWOULDBLOCK) {
          fprintf(stderr, "libev callbacked called without data to " \
-                         "recieve (conn: %s)", conn->ip);
+                         "receive (conn: %s)", conn->ip);
          return;
       }
       perror("recv");
       ws_conn_kill(conn);
       return;
    } else if (recieved == 0) {
-      printf("ws: Connection closed by %s\n", conn->ip);
+      printf("[ws] Connection closed by %s\n", conn->ip);
       ws_conn_kill(conn);
       return;
    }
@@ -395,7 +395,7 @@ static void ws_conn_accept(
          get_in_addr(in_addr),
          ip_string,
          sizeof ip_string);
-   printf("ws: Got connection from %s\n", ip_string);
+   printf("[ws] Got connection from %s\n", ip_string);
 
    // Create conn and parser
    conn = malloc(sizeof(struct ws_conn));
@@ -583,7 +583,7 @@ void ws_conn_kill(struct ws_conn *conn)
    struct ws_settings *settings = &conn->instance->settings;
 
    // Print messange
-   printf("ws: Killing connection %s\n", conn->ip);
+   printf("[ws] Killing connection %s\n", conn->ip);
 
    int sockfd = conn->recv_watcher.fd;
 
@@ -688,7 +688,7 @@ int ws_start(struct ws *instance)
    }
 
    // Print message
-   printf("ws: Starting server on port '%s'\n", instance->port_str);
+   printf("[ws] Starting server on port '%s'\n", instance->port_str);
 
    // Bind to socket
    instance->sockfd = bind_listen(instance->port_str);


### PR DESCRIPTION
These commits includes API breaking changes!

Changelist:
- Request is no longer marked as const in homeport.h
- Printf improvements
- IP Addresses are now correct
- JSON, XML, and URIs are now only included in the REST module.
- IDs are no longer auto generated, the adapter needs to supply these.
- Uniqueness checks on IDs:
  - Adapter IDs must be unique across adapters.
  - Device IDs must be unique in an adapter.
  - Service IDs must be unique in a device.
- URIs in REST will now be encoded with Curl.
- A new listener type for listening on device attach/detach on a single adapter
- isActuator is now set based on the presence of the get callback and no longer explicitly given by the adapter.
- Various bugfixes
